### PR TITLE
[FEAT] 비밀번호 찾기 로직 구현 #45

### DIFF
--- a/src/main/java/com/sixbald/webide/config/SecurityConfig.java
+++ b/src/main/java/com/sixbald/webide/config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
                 .addFilter(corsFilter())
                 .authorizeHttpRequests(request -> request
                         .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/emailcheck", "/api/v1/auth/sendmail",
-                                "/api/v1/auth/reissue", "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**")
+                                "/api/v1/auth/reissue", "/api/v1/auth/nickcheck","/api/v1/auth/findpassword","/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**")
                         .permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/sixbald/webide/user/UserController.java
+++ b/src/main/java/com/sixbald/webide/user/UserController.java
@@ -25,42 +25,42 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@Tag(name="유저 컨트롤러")
+@Tag(name = "유저 컨트롤러")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
 public class UserController {
 
     private final UserService userService;
 
-    @ApiResponses(value={
+    @ApiResponses(value = {
             @ApiResponse(description = "회원가입 성공", responseCode = "200"),
             @ApiResponse(description = "회원가입 실패", responseCode = "400")
     })
     @PostMapping("/signup")
-    public Response<Void> signup(@RequestBody @Valid UserSignupRequest dto){
+    public Response<Void> signup(@RequestBody @Valid UserSignupRequest dto) {
         userService.signup(dto);
         return Response.success("회원가입 성공");
     }
 
-    @ApiResponses(value={
+    @ApiResponses(value = {
             @ApiResponse(description = "로그인 성공", responseCode = "200"),
             @ApiResponse(description = "로그인 실패", responseCode = "400")
     })
     @PostMapping("/login")
-    public Response<UserLoginResponse> login(@RequestBody UserLoginRequest request){
+    public Response<UserLoginResponse> login(@RequestBody UserLoginRequest request) {
         return Response.success("로그인에 성공했습니다.", userService.login(request));
     }
 
     @PostMapping("/reissue")
-    public Response<UserLoginResponse> reissue(@RequestBody RefreshTokenRequest request){
+    public Response<UserLoginResponse> reissue(@RequestBody RefreshTokenRequest request) {
         return Response.success("토큰 발급에 성공했습니다.", userService.reissue(request.getRefreshToken()));
     }
 
-    @ApiResponses(value={
+    @ApiResponses(value = {
             @ApiResponse(description = "로그아웃 성공", responseCode = "200")
     })
     @PostMapping("/logout")
-    public Response<Void> logout(){
+    public Response<Void> logout() {
         return Response.success("로그아웃 되었습니다.");
     }
     // 프로필 조회
@@ -69,7 +69,7 @@ public class UserController {
     @Operation(summary = "프로필 조회")
     public Response<UserDTO> findUserInfo(
             @AuthenticationPrincipal LoginUser loginUser
-    ){
+    ) {
         Long userId = loginUser.getUser().getId();
         UserDTO data = userService.getUserInfo(userId);
         return Response.success("회원 조회에 성공하셨습니다", data);
@@ -92,7 +92,7 @@ public class UserController {
     public Response<Void> updateNickname(
             @RequestBody RequestNickname requestNickname,
             @AuthenticationPrincipal LoginUser loginUser
-    ){
+    ) {
         return userService.updateNickname(loginUser.getUser().getId(), requestNickname);
     }
 
@@ -100,11 +100,10 @@ public class UserController {
     public Response<Void> nicknameCheck(@RequestBody NicknameRequest request) {
         return userService.nicknameCheck(request);
     }
-    // TODO @Authentication 처리해줘야 한다.
 
     @PostMapping("/password")
-    public Response<Void> passwordEdit(@RequestBody @Valid PasswordRequest request, @AuthenticationPrincipal LoginUser loginUser)   {
-        return userService.passwordEdit(request,loginUser);
+    public Response<Void> passwordEdit(@RequestBody @Valid PasswordRequest request, @AuthenticationPrincipal LoginUser loginUser) {
+        return userService.passwordEdit(request, loginUser);
     }
 
     @PostMapping("/sendmail")
@@ -115,5 +114,10 @@ public class UserController {
     @PostMapping("/emailcheck")
     public Response<Void> emailCheck(@RequestBody EmailCheckRequest request) {
         return userService.emailCheck(request);
+    }
+
+    @PostMapping("/findpassword")
+    public Response<Void> findPassword(@RequestBody FindPasswordRequest request) {
+        return userService.findPassword(request);
     }
 }

--- a/src/main/java/com/sixbald/webide/user/UserService.java
+++ b/src/main/java/com/sixbald/webide/user/UserService.java
@@ -245,7 +245,6 @@ public class UserService {
         if (findMember != null) {
             String tempPassword = getTempPassword();
             findMember.updatePassword(passwordEncoder.encode(tempPassword));
-            userRepository.save(findMember);
 
             simpleMailMessage.setTo(email);
             simpleMailMessage.setSubject("Web_IDE 임시 비밀번호 발급" );

--- a/src/main/java/com/sixbald/webide/user/UserService.java
+++ b/src/main/java/com/sixbald/webide/user/UserService.java
@@ -246,6 +246,7 @@ public class UserService {
             String tempPassword = getTempPassword();
             findMember.updatePassword(passwordEncoder.encode(tempPassword));
 
+
             simpleMailMessage.setTo(email);
             simpleMailMessage.setSubject("Web_IDE 임시 비밀번호 발급" );
             simpleMailMessage.setText("임시 비밀번호는 " + tempPassword + "입니다");

--- a/src/main/java/com/sixbald/webide/user/dto/request/FindPasswordRequest.java
+++ b/src/main/java/com/sixbald/webide/user/dto/request/FindPasswordRequest.java
@@ -1,0 +1,8 @@
+package com.sixbald.webide.user.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class FindPasswordRequest {
+    private String email;
+}


### PR DESCRIPTION
1. 이메일 입력 시, 임시 비밀번호 해당 이메일로 발급 
2. 비밀번호는 정규식에 맞췄으며, 숫자와 영문 소문자를 포함한 길이가 8에서 12 사이의 임시 비밀번호를 생성한다.
3. 임시 비밀번호는 DB에 암호화되어 저장된다. 
4. 비밀번호 수정 로직은 기존에 있던 비밀번호 수정 API를 이용한다. 

실행에 대한 성공, 실패는 노션페이지에서 확인할 수 있다.
https://www.notion.so/POST-api-v1-auth-findpassword-8f4772982d714aec8898b313741fd355?pvs=4